### PR TITLE
To avoid sqlite3.ProgrammingError when interleaving threads

### DIFF
--- a/qdrant_client/local/persistence.py
+++ b/qdrant_client/local/persistence.py
@@ -25,7 +25,7 @@ def try_migrate_to_sqlite(location: str) -> None:
     try:
         dbm_storage = dbm.open(str(dbm_path), "c")
 
-        con = sqlite3.connect(str(sql_path))
+        con = sqlite3.connect(str(sql_path), , check_same_thread=False)
         cur = con.cursor()
 
         # Create table
@@ -73,7 +73,7 @@ class CollectionPersistence:
 
         self.location = Path(location) / STORAGE_FILE_NAME
         self.location.parent.mkdir(exist_ok=True, parents=True)
-        self.storage = sqlite3.connect(str(self.location))
+        self.storage = sqlite3.connect(str(self.location), check_same_thread=False)
         self._ensure_table()
 
     def close(self) -> None:


### PR DESCRIPTION
When using multi-threads application (e.g., web server gate interface; wsgi), each thread attempt to access client object which has sqlite connection.
In this case, current version of Qdrant occurs sqlite3.ProgrammingError due to the simultaneous access.

Error messages is here:
```
sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread.
```

This error should be solved when your program runs on web server application (e.g., wgsi)

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
